### PR TITLE
Fix container image publish

### DIFF
--- a/.github/workflows/container-image-publish.yml
+++ b/.github/workflows/container-image-publish.yml
@@ -73,8 +73,6 @@ jobs:
       # https://github.com/sigstore/cosign
       - name: Sign the published Docker image
         if: ${{ github.event_name != 'pull_request' }}
-        env:
-          COSIGN_EXPERIMENTAL: "true"
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
-        run: cosign sign ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}
+        run: cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}


### PR DESCRIPTION
Make cosign signing work again by supplying the --yes option to avoid the interactive prompt. COSIGN_EXPERIMENTAL is not longer necessary and seemlingly (currently) detrimental.